### PR TITLE
Remove kotlin from ksp version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.0.0' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
-    id "com.google.devtools.ksp" version "$kotlin_version-1.0.9" apply false
+    id "com.google.devtools.ksp" version "1.8.10-1.0.9" apply false
     id "com.diffplug.spotless" version "6.18.0" apply false
     id "io.gitlab.arturbosch.detekt" version "1.22.0"
 }


### PR DESCRIPTION
Allows renovate to update ksp correctly